### PR TITLE
Refactor Dockerfile to use ECR base image with New Relic

### DIFF
--- a/.github/workflows/aws_main-game.yml
+++ b/.github/workflows/aws_main-game.yml
@@ -57,7 +57,9 @@ jobs:
     # Build & Push da API
     - name: Build and push API image
       run: |
-        docker build -t ${{env.FCG_API_NAME}} -f ${{env.FCG_API_DOCKERFILE}} .
+        docker build --build-arg AWS_REGION=${{ vars.AWS_REGION }} \
+        --build-arg AWS_ACCOUNT_ID=${{ vars.AWS_ACCOUNT_ID }} \
+        -t ${{env.FCG_API_NAME}} -f ${{env.FCG_API_DOCKERFILE}} .
         docker tag ${{env.FCG_API_NAME}}:latest ${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/${{env.FCG_API_NAME}}:latest
         docker push ${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/${{env.FCG_API_NAME}}:latest
 

--- a/FCG.Games.API/Dockerfile
+++ b/FCG.Games.API/Dockerfile
@@ -1,32 +1,5 @@
 ﻿# See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-# This stage is used when running from VS in fast mode (Default for Debug configuration)
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
-USER $APP_UID
-WORKDIR /app
-EXPOSE 8080
-EXPOSE 8081
-
-# Enable the agent
-ENV CORECLR_ENABLE_PROFILING=1 \
-CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A} \
-CORECLR_NEWRELIC_HOME=/usr/local/newrelic-dotnet-agent \
-CORECLR_PROFILER_PATH=/usr/local/newrelic-dotnet-agent/libNewRelicProfiler.so \
-NEW_RELIC_LICENSE_KEY=49fea977ae8cb8915399b2c027e24687FFFFNRAL \
-NEW_RELIC_APP_NAME="fcg-game-api"
-
-# ✅ Troca para root para conseguir instalar pacotes
-USER root
-
-RUN apt-get update && \
-    apt-get install -y wget ca-certificates gnupg && \
-    mkdir -p /usr/share/keyrings && \
-    wget -O- https://download.newrelic.com/548C16BF.gpg | gpg --dearmor -o /usr/share/keyrings/newrelic-archive-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/newrelic-archive-keyring.gpg] http://apt.newrelic.com/debian/ newrelic non-free" > /etc/apt/sources.list.d/newrelic.list && \
-    apt-get update && \
-    apt-get install -y newrelic-dotnet-agent && \
-    rm -rf /var/lib/apt/lists/*
-
 # This stage is used to build the service project
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ARG BUILD_CONFIGURATION=Release
@@ -45,8 +18,11 @@ FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
 RUN dotnet publish "./FCG.Games.API.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
-# This stage is used in production or when running from VS in regular mode (Default when not using the Debug configuration)
-FROM base AS final
+
+# Stage final: usa a imagem do ECR com aspnet + new relic
+ARG AWS_ACCOUNT_ID
+ARG AWS_REGION
+FROM ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/aspnet-newrelic-runtime:latest AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "FCG.Games.API.dll"]


### PR DESCRIPTION
Refactor Dockerfile to use ECR base image with New Relic

Updated GitHub Actions workflow to pass AWS_REGION and AWS_ACCOUNT_ID as build args to Docker. Refactored Dockerfile to remove manual New Relic installation and user switching, instead using a pre-built aspnet-newrelic-runtime image from ECR. This simplifies the build process and centralizes runtime dependencies.