### PR TITLE
Docker args fix

### DIFF
--- a/FCG.Games.API/Dockerfile
+++ b/FCG.Games.API/Dockerfile
@@ -1,4 +1,7 @@
 ﻿# See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
+ARG AWS_ACCOUNT_ID
+ARG AWS_REGION
+ARG BASE_RUNTIME_IMAGE=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/aspnet-newrelic-runtime:latest
 
 # This stage is used to build the service project
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
@@ -20,9 +23,7 @@ RUN dotnet publish "./FCG.Games.API.csproj" -c $BUILD_CONFIGURATION -o /app/publ
 
 
 # Stage final: usa a imagem do ECR com aspnet + new relic
-ARG AWS_ACCOUNT_ID
-ARG AWS_REGION
-FROM ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/aspnet-newrelic-runtime:latest AS final
+FROM ${BASE_RUNTIME_IMAGE} AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "FCG.Games.API.dll"]


### PR DESCRIPTION
Docker args fix

#### PR Classification
Code cleanup and build process improvement to use a custom runtime image from ECR.

#### PR Summary
This PR updates the Dockerfile and CI workflow to use a prebuilt ASP.NET + New Relic runtime image from Amazon ECR, simplifying the build and deployment process.
- Dockerfile: Replaces manual New Relic installation with a custom ECR base image and adds build arguments for AWS account and region.
- aws_main-game.yml: Passes AWS_REGION and AWS_ACCOUNT_ID as build arguments during Docker build to support the new Dockerfile setup.
